### PR TITLE
Fix example install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project provides tools for PyTorch CI/CD analytics including:
 ## Usage (for humans)
 
 ```bash
-claude mcp add hud /path/to/uvx --from "git+https://github.com/izaitsevfb/claude-pytorch-treehugger.git" pytorch-hud
+claude mcp add hud -- $(which uvx) --from "git+https://github.com/izaitsevfb/claude-pytorch-treehugger.git" pytorch-hud
 ```
 
 ## Development


### PR DESCRIPTION
Without the double dash after `hud` we get an error.
```
claude mcp add hud $(which uvx) --from "git+https://github.com/izaitsevfb/claude-pytorch-treehugger.git" pytorch-hud
error: unknown option '--from'
```

I also updated it to `$(which uvx)` instead of `/path/to/uvx` to make it easier to just copy/paste to install.