### PR TITLE
Pin mcp<2 to avoid breaking 2.0.0 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.25.0
 types-requests>=2.25.0
-mcp>=1.3.0
+mcp>=1.3.0,<2
 python-dotenv>=0.21.0
 mypy>=1.3.0
 ruff>=0.0.270

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "fastapi",
         "uvicorn",
         "pydantic",
-        "mcp>=1.3.0",
+        "mcp>=1.3.0,<2",
         "python-dotenv>=0.21.0",
     ],
     classifiers=[


### PR DESCRIPTION
`mcp` 2.0.0 was published to PyPI on 2026-07-28 — a breaking major-version bump. The current unbounded `mcp>=1.3.0` constraint (in both `requirements.txt` and `setup.py`) makes fresh `pip install` / `uvx --from git+…` resolves pull 2.0.0 and break installs.

This pins `mcp>=1.3.0,<2` to stay on the compatible 1.x line (latest 1.x is 1.29.0). No functional code changes.